### PR TITLE
Rider cleanup and optimize

### DIFF
--- a/Celestefall.yyp
+++ b/Celestefall.yyp
@@ -16,6 +16,7 @@
     {"id":{"name":"o_solid_mover","path":"objects/o_solid_mover/o_solid_mover.yy",},"order":2,},
     {"id":{"name":"o_solid_oneway","path":"objects/o_solid_oneway/o_solid_oneway.yy",},"order":2,},
     {"id":{"name":"o_platform_reverser","path":"objects/o_platform_reverser/o_platform_reverser.yy",},"order":4,},
+    {"id":{"name":"scr_celestefall_utils","path":"scripts/scr_celestefall_utils/scr_celestefall_utils.yy",},"order":3,},
     {"id":{"name":"s_solid","path":"sprites/s_solid/s_solid.yy",},"order":0,},
     {"id":{"name":"s_player_idle","path":"sprites/s_player_idle/s_player_idle.yy",},"order":0,},
     {"id":{"name":"s_clouds","path":"sprites/s_clouds/s_clouds.yy",},"order":1,},

--- a/objects/o_player/Create_0.gml
+++ b/objects/o_player/Create_0.gml
@@ -5,9 +5,6 @@ grav		= 0.5;
 jumpspd		= -8;
 maxfallspd	= 6;
 
-function on_solid() {
-	return (place_meeting(x, y+1, o_solid) || place_meeting(x, y+1, o_solid_oneway));
-}
 
 function squash() {
 	show_debug_message("squashed");

--- a/objects/o_solid/CleanUp_0.gml
+++ b/objects/o_solid/CleanUp_0.gml
@@ -1,0 +1,2 @@
+ds_list_destroy(list_of_riders);
+

--- a/objects/o_solid/Create_0.gml
+++ b/objects/o_solid/Create_0.gml
@@ -35,25 +35,19 @@
 			while (_move != 0) {
 				if (!place_meeting(x+_dir, y, o_solid)) {
 					x += _dir;
-				
-					//pushing/carrying player while moving RIGHT
-					if (_move > 0) {
-						with (o_actor) {
-							if (place_meeting(x, y, other)) {
-								move_x(other.bbox_right-bbox_left+_dir, squash); 
-							} else if (ds_list_find_index(other.list_of_riders, id) != -1) {
-								move_x(_dir);
-							}
-						}
 					
-					//pushing/carrying player while moving LEFT
-					} else {
-						with (o_actor) {
-							if (place_meeting(x, y, other)) {
+					// Carry actors
+					with (o_actor) {
+						if (place_meeting(x, y, other)) {
+							if (_move > 0) {
+								// Carry while moving right
+								move_x(other.bbox_right-bbox_left+_dir, squash);
+							} else {
+								// Carry while moving left
 								move_x(other.bbox_left-bbox_right+_dir, squash);
-							} else if (ds_list_find_index(other.list_of_riders, id) != -1) {
-								move_x(_dir);
 							}
+						} else if (ds_list_find_index(other.list_of_riders, id) != -1) {
+							move_x(_dir);
 						}
 					}
 				
@@ -80,27 +74,22 @@
 			while (_move != 0) {
 				if (!place_meeting(x, y+_dir, o_solid)) {
 					y += _dir;
-				
-					//pushing/carrying player while moving DOWN
-					if (_move > 0) {		
-						with (o_actor) {
-							if (place_meeting(x, y, other)) {
+					
+					// Carry actors
+					with (o_actor) {
+						if (place_meeting(x, y, other)) {
+							if (_move > 0) {
+								// Carry while moving down
 								move_y(other.bbox_bottom-bbox_top+_dir, squash);
-							} else if (ds_list_find_index(other.list_of_riders,id) != -1) {
-								move_y(_dir);
-							}
-						}	
-						
-					//pushing/carrying player while moving UP
-					} else {
-						with (o_actor) {
-							if (place_meeting(x, y, other)) {
+							} else {
+								// Carry while moving up
 								move_y(other.bbox_top-bbox_bottom+_dir, squash);
-							} else if (ds_list_find_index(other.list_of_riders,id) != -1) {
-								move_y(_dir);
 							}
+						} else if (ds_list_find_index(other.list_of_riders, id) != -1) {
+							move_y(_dir);
 						}
-					} 
+					}
+					
 					_move -= _dir;
 				
 				} else {

--- a/objects/o_solid/Create_0.gml
+++ b/objects/o_solid/Create_0.gml
@@ -1,4 +1,6 @@
 #region Initialize
+
+	list_of_riders = ds_list_create();
 	
 	//movement variables
 	xspd = 0;
@@ -9,23 +11,6 @@
 
 	dir = 1; //movement direction
 	
-#endregion
-
-#region Utils
-
-	//populate a list of all actors who are riding the solid
-	//Returns: a DS list of actors riding the solid
-	function get_rider_list() {
-		var _list_of_riders = ds_list_create();
-		ds_list_clear(_list_of_riders);
-
-		with (o_actor) {
-			if (is_riding(other)) ds_list_add(_list_of_riders,id);
-		}
-		
-		return _list_of_riders;
-	}
-
 #endregion
 
 #region Movement and collision
@@ -45,7 +30,7 @@
 			xspd_remainder -= _move;
 			var _dir = sign(_move);
 	
-			var _list_of_riders = get_rider_list();
+			get_rider_list(list_of_riders);
 		
 			while (_move != 0) {
 				if (!place_meeting(x+_dir, y, o_solid)) {
@@ -56,7 +41,7 @@
 						with (o_actor) {
 							if (place_meeting(x, y, other)) {
 								move_x(other.bbox_right-bbox_left+_dir, squash); 
-							} else if (ds_list_find_index(_list_of_riders,id) != -1) {
+							} else if (ds_list_find_index(other.list_of_riders, id) != -1) {
 								move_x(_dir);
 							}
 						}
@@ -66,7 +51,7 @@
 						with (o_actor) {
 							if (place_meeting(x, y, other)) {
 								move_x(other.bbox_left-bbox_right+_dir, squash);
-							} else if (ds_list_find_index(_list_of_riders,id) != -1) {
+							} else if (ds_list_find_index(other.list_of_riders, id) != -1) {
 								move_x(_dir);
 							}
 						}
@@ -75,11 +60,9 @@
 					_move -= _dir;
 				} else {
 					collision_event();
-					ds_list_destroy(_list_of_riders);
 					break;
 				}
 			}
-			ds_list_destroy(_list_of_riders);
 		}
 	}
 	
@@ -92,7 +75,7 @@
 			yspd_remainder -= _move;
 			var _dir = sign(_move);
 	
-			var _list_of_riders = get_rider_list();
+			get_rider_list(list_of_riders);
 
 			while (_move != 0) {
 				if (!place_meeting(x, y+_dir, o_solid)) {
@@ -103,7 +86,7 @@
 						with (o_actor) {
 							if (place_meeting(x, y, other)) {
 								move_y(other.bbox_bottom-bbox_top+_dir, squash);
-							} else if (ds_list_find_index(_list_of_riders,id) != -1) {
+							} else if (ds_list_find_index(other.list_of_riders,id) != -1) {
 								move_y(_dir);
 							}
 						}	
@@ -113,7 +96,7 @@
 						with (o_actor) {
 							if (place_meeting(x, y, other)) {
 								move_y(other.bbox_top-bbox_bottom+_dir, squash);
-							} else if (ds_list_find_index(_list_of_riders,id) != -1) {
+							} else if (ds_list_find_index(other.list_of_riders,id) != -1) {
 								move_y(_dir);
 							}
 						}
@@ -122,11 +105,9 @@
 				
 				} else {
 					collision_event();
-					ds_list_destroy(_list_of_riders);
 					break;
 				}
 			}
-			ds_list_destroy(_list_of_riders);
 		}
 	}
 		

--- a/objects/o_solid/Create_0.gml
+++ b/objects/o_solid/Create_0.gml
@@ -21,9 +21,8 @@
 	//then carry any riding actors
 	//Param: _xspd,_yspd (amount to move solid in current frame)
 	//Param: _collision_event (function to execute when a collision is detected (defaults to no action))
-	function move_x(_xspd, collision_event = function() {}) {
+	function move_x(_xspd, _collision_event = function() {}) {
 		xspd_remainder += _xspd;
-		var _move = xspd_remainder;
 		var _move = round(xspd_remainder);
 	
 		if (_move != 0) {		
@@ -33,36 +32,38 @@
 			get_rider_list(list_of_riders);
 		
 			while (_move != 0) {
-				if (!place_meeting(x+_dir, y, o_solid)) {
-					x += _dir;
-					
-					// Carry actors
-					with (o_actor) {
-						if (place_meeting(x, y, other)) {
-							if (_move > 0) {
-								// Carry while moving right
-								move_x(other.bbox_right-bbox_left+_dir, squash);
-							} else {
-								// Carry while moving left
-								move_x(other.bbox_left-bbox_right+_dir, squash);
-							}
-						} else if (ds_list_find_index(other.list_of_riders, id) != -1) {
-							move_x(_dir);
-						}
-					}
 				
-					_move -= _dir;
-				} else {
-					collision_event();
+				// Check for collision in next spot
+				var colliding_instance = instance_place(x+_dir, y, o_solid);
+				if (colliding_instance != noone) {
+					_collision_event(colliding_instance);
 					break;
 				}
+				
+				x += _dir;
+					
+				// Carry actors
+				with (o_actor) {
+					if (place_meeting(x, y, other)) {
+						if (_move > 0) {
+							// Carry while moving right
+							move_x(other.bbox_right-bbox_left+_dir, squash);
+						} else {
+							// Carry while moving left
+							move_x(other.bbox_left-bbox_right+_dir, squash);
+						}
+					} else if (ds_list_find_index(other.list_of_riders, id) != -1) {
+						move_x(_dir);
+					}
+				}
+				
+				_move -= _dir;
 			}
 		}
 	}
 	
-	function move_y(_yspd, collision_event = function() {}) {
+	function move_y(_yspd, _collision_event = function() {}) {
 		yspd_remainder += _yspd;
-		var _move = yspd_remainder;
 		var _move = round(yspd_remainder);
 	
 		if (_move != 0) {		
@@ -72,30 +73,32 @@
 			get_rider_list(list_of_riders);
 
 			while (_move != 0) {
-				if (!place_meeting(x, y+_dir, o_solid)) {
-					y += _dir;
-					
-					// Carry actors
-					with (o_actor) {
-						if (place_meeting(x, y, other)) {
-							if (_move > 0) {
-								// Carry while moving down
-								move_y(other.bbox_bottom-bbox_top+_dir, squash);
-							} else {
-								// Carry while moving up
-								move_y(other.bbox_top-bbox_bottom+_dir, squash);
-							}
-						} else if (ds_list_find_index(other.list_of_riders, id) != -1) {
-							move_y(_dir);
-						}
-					}
-					
-					_move -= _dir;
 				
-				} else {
-					collision_event();
+				// Check for collision in next spot
+				var colliding_instance = instance_place(x, y+_dir, o_solid);
+				if (colliding_instance != noone) {
+					_collision_event(colliding_instance);
 					break;
 				}
+				
+				y += _dir;
+					
+				// Carry actors
+				with (o_actor) {
+					if (place_meeting(x, y, other)) {
+						if (_move > 0) {
+							// Carry while moving down
+							move_y(other.bbox_bottom-bbox_top+_dir, squash);
+						} else {
+							// Carry while moving up
+							move_y(other.bbox_top-bbox_bottom+_dir, squash);
+						}
+					} else if (ds_list_find_index(other.list_of_riders, id) != -1) {
+						move_y(_dir);
+					}
+				}
+					
+				_move -= _dir;
 			}
 		}
 	}

--- a/objects/o_solid/o_solid.yy
+++ b/objects/o_solid/o_solid.yy
@@ -22,6 +22,7 @@
   "physicsShapePoints": [],
   "eventList": [
     {"isDnD":false,"eventNum":0,"eventType":0,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
+    {"isDnD":false,"eventNum":0,"eventType":12,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
   ],
   "properties": [],
   "overriddenProperties": [],

--- a/objects/o_solid_oneway/CleanUp_0.gml
+++ b/objects/o_solid_oneway/CleanUp_0.gml
@@ -1,0 +1,2 @@
+ds_list_destroy(list_of_riders);
+

--- a/objects/o_solid_oneway/Create_0.gml
+++ b/objects/o_solid_oneway/Create_0.gml
@@ -1,5 +1,7 @@
 #region Initialize
 	
+	list_of_riders = ds_list_create();
+	
 	//movement variables
 	xspd = 0;
 	xspd_remainder = 0;
@@ -9,23 +11,6 @@
 
 	dir = 1; //movement direction
 	
-#endregion
-
-#region Utils
-
-	//populate a list of all actors who are riding the solid
-	//Returns: a DS list of actors riding the solid
-	function get_rider_list() {
-		var _list_of_riders = ds_list_create();
-		ds_list_clear(_list_of_riders);
-
-		with (o_actor) {
-			if (is_riding(other)) ds_list_add(_list_of_riders,id);
-		}
-		
-		return _list_of_riders;
-	}
-
 #endregion
 
 #region Movement and collision
@@ -73,7 +58,7 @@
 			yspd_remainder -= _move;
 			var _dir = sign(_move);
 	
-			var _list_of_riders = get_rider_list();
+			get_rider_list(list_of_riders);
 
 				while (_move != 0) {
 				if (!place_meeting(x, y+_dir, o_solid)) {
@@ -82,7 +67,7 @@
 					//moving DOWN
 					if (_move > 0) {
 						with (o_actor) {
-							if (ds_list_find_index(_list_of_riders,id) != -1 && bbox_bottom <= other.bbox_top) {
+							if (ds_list_find_index(other.list_of_riders,id) != -1 && bbox_bottom <= other.bbox_top) {
 								move_y(_dir);
 							}
 						}	
@@ -93,21 +78,19 @@
 							if (bbox_bottom <= other.bbox_top) {
 								if (place_meeting(x, y, other)) {
 									move_y(other.bbox_top-bbox_bottom+_dir, squash);
-								} else if (ds_list_find_index(_list_of_riders,id) != -1) {
+								} else if (ds_list_find_index(other.list_of_riders,id) != -1) {
 									move_y(_dir);
 								}
 							}
 						}
-					} 
+					}
 					_move -= _dir;
 				
 				} else {
 					collision_event();
-					ds_list_destroy(_list_of_riders);
 					break;
 				}
 			}
-			ds_list_destroy(_list_of_riders);
 		}
 	}
 		

--- a/objects/o_solid_oneway/o_solid_oneway.yy
+++ b/objects/o_solid_oneway/o_solid_oneway.yy
@@ -19,6 +19,7 @@
   "physicsShapePoints": [],
   "eventList": [
     {"isDnD":false,"eventNum":0,"eventType":0,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
+    {"isDnD":false,"eventNum":0,"eventType":12,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
   ],
   "properties": [],
   "overriddenProperties": [],

--- a/scripts/scr_celestefall_utils/scr_celestefall_utils.gml
+++ b/scripts/scr_celestefall_utils/scr_celestefall_utils.gml
@@ -1,0 +1,14 @@
+function on_solid() {
+	return (place_meeting(x, y+1, o_solid) || place_meeting(x, y+1, o_solid_oneway));
+}
+
+// Populate a referenced list of all actors who are riding the solid
+// Returns: void
+function get_rider_list(_list_of_riders) {
+	ds_list_clear(_list_of_riders);
+
+	with (o_actor) {
+		if (is_riding(other)) ds_list_add(_list_of_riders, id);
+	}
+}
+

--- a/scripts/scr_celestefall_utils/scr_celestefall_utils.yy
+++ b/scripts/scr_celestefall_utils/scr_celestefall_utils.yy
@@ -1,0 +1,12 @@
+{
+  "isDnD": false,
+  "isCompatibility": false,
+  "parent": {
+    "name": "Celestefall",
+    "path": "folders/Celestefall.yy",
+  },
+  "resourceVersion": "1.0",
+  "name": "scr_celestefall_utils",
+  "tags": [],
+  "resourceType": "GMScript",
+}


### PR DESCRIPTION
Did some refactoring to o_solid. All the logic should be functionally the same, just organized to remove redundancy. I also made it so the ds_list is re-used by the object until the object is garbage collected. This way it isn't getting created and destroyed each frame